### PR TITLE
Handle schema contents with media type

### DIFF
--- a/route.go
+++ b/route.go
@@ -55,8 +55,6 @@ type SchemaValue struct {
 	Content     interface{}
 	Description string
 
-	// ContentType is to be used only with RequestBody. Valid ContentType
-	// are application/json or multipart/form-data.
 	ContentType               string
 	AllowAdditionalProperties bool
 }
@@ -227,7 +225,13 @@ func (r Router) resolveParameterSchema(paramType string, paramConfig map[string]
 				return err
 			}
 		}
-		param = param.WithSchema(schema)
+
+		if v.ContentType != "" {
+			param.Content = openapi3.NewContent()
+			param.Content[v.ContentType] = openapi3.NewMediaType().WithSchema(schema)
+		} else {
+			param = param.WithSchema(schema)
+		}
 
 		if v.Description != "" {
 			param = param.WithDescription(v.Description)

--- a/route_test.go
+++ b/route_test.go
@@ -686,6 +686,34 @@ func TestResolveParametersSchema(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("invalid param type"),
 		},
+		{
+			name:      "content param",
+			paramType: "query",
+			paramsSchema: map[string]SchemaValue{
+				"foo": {
+					Content:     &TestStruct{},
+					ContentType: "application/json",
+				},
+			},
+			expectedJSON: `{
+				"parameters": [{
+					"in": "query",
+					"name": "foo",
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"message": {"type": "string"}
+								},
+								"additionalProperties": false
+							}
+						}
+					}
+				}],
+				"responses": null
+			}`,
+		},
 	}
 
 	mux := mux.NewRouter()

--- a/testdata/schema-no-content.json
+++ b/testdata/schema-no-content.json
@@ -32,20 +32,10 @@
           }
         ],
         "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {}
-            }
-          },
           "description": "request body without schema"
         },
         "responses": {
           "204": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
             "description": ""
           }
         }

--- a/testdata/users_employees.json
+++ b/testdata/users_employees.json
@@ -162,7 +162,7 @@
         "responses": {
           "201": {
             "content": {
-              "application/json": {
+              "text/html": {
                 "schema": {
                   "type": "string"
                 }


### PR DESCRIPTION
Add contents media type to generated swagger. Fix a wrong test passing no request body content.